### PR TITLE
Use system timeval struct for MinGW as described in lwip/sockets.h

### DIFF
--- a/ports/win32/include/arch/cc.h
+++ b/ports/win32/include/arch/cc.h
@@ -40,6 +40,11 @@
 #pragma warning (disable: 4711) /* The compiler performed inlining on the given function, although it was not marked for inlining */
 #endif
 
+#ifdef __MINGW32__
+#define LWIP_TIMEVAL_PRIVATE 0
+#include <sys/time.h>
+#endif
+
 #ifdef _MSC_VER
 #if _MSC_VER >= 1910
 #include <errno.h> /* use MSVC errno for >= 2017 */


### PR DESCRIPTION
MSVC doesn't have `sys/time.h` and therefore needs the lwip implementation of `struct timeval`. But MinGW is based on GCC and therefore does implement `sys/time.h`, but because it's building for Windows, it uses the win32 port in lwip-contrib which doesn't expect `sys/time.h` to be available.

So if we ever include anything that leads to a #include <sys/time.h>, we cause problems for the MinGW build.

---

From sockets.h:

```c++
/** LWIP_TIMEVAL_PRIVATE: if you want to use the struct timeval provided
 * by your system, set this to 0 and include <sys/time.h> in cc.h */
#ifndef LWIP_TIMEVAL_PRIVATE
#define LWIP_TIMEVAL_PRIVATE 1
#endif

#if LWIP_TIMEVAL_PRIVATE
struct timeval {
  long    tv_sec;         /* seconds */
  long    tv_usec;        /* and microseconds */
};
#endif /* LWIP_TIMEVAL_PRIVATE */
```